### PR TITLE
Improvements

### DIFF
--- a/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/CollapsingTopBar.kt
+++ b/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/CollapsingTopBar.kt
@@ -57,8 +57,8 @@ import kotlin.math.roundToInt
  * - transformations based on [CollapsingTopBarState.layoutInfo]
  * - custom layout logic with [CollapsingTopBarNestedCollapseElement]
  *
- * @param state the state that manages this top bar.
  * @param modifier the [Modifier] to be applied to this top bar.
+ * @param state the state that manages this top bar.
  * @param clipToBounds the flag whether or not to automatically clip top bar [content] to the
  * actual collapse height.
  *
@@ -68,8 +68,8 @@ import kotlin.math.roundToInt
  */
 @Composable
 fun CollapsingTopBar(
-    state: CollapsingTopBarState,
     modifier: Modifier = Modifier,
+    state: CollapsingTopBarState = rememberCollapsingTopBarState(),
     clipToBounds: Boolean = true,
     content: @Composable CollapsingTopBarScope.() -> Unit,
 ) {

--- a/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/CollapsingTopBarState.kt
+++ b/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/CollapsingTopBarState.kt
@@ -22,6 +22,8 @@ import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -70,6 +72,20 @@ class CollapsingTopBarState internal constructor(
     ) : this(
         initialHeight = if (isExpanded) Float.MAX_VALUE else 0f,
     )
+
+    /**
+     * Whether top bar height has reached its minimum height.
+     */
+    val isCollapsed: Boolean by derivedStateOf {
+        layoutInfo.isCollapsed
+    }
+
+    /**
+     * Whether top bar height has reached its maximum height.
+     */
+    val isExpanded: Boolean by derivedStateOf {
+        layoutInfo.isExpanded
+    }
 
     /**
      * The layout info object calculated during the last layout pass.
@@ -234,18 +250,18 @@ data class CollapsingTopBarLayoutInfo(
     /**
      * The total variable height amount that may collapse.
      */
-    val collapsibleDistance: Int
+    internal val collapsibleDistance: Int
         get() = expandedHeight - collapsedHeight
 
     /**
      * Whether top bar height has reached its minimum height.
      */
-    val isCollapsed: Boolean
+    internal val isCollapsed: Boolean
         get() = height == collapsedHeight.toFloat()
 
     /**
      * Whether top bar height has reached its maximum height.
      */
-    val isExpanded: Boolean
+    internal val isExpanded: Boolean
         get() = height == expandedHeight.toFloat()
 }

--- a/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/dependent/CollapsingTopBarExitState.kt
+++ b/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/dependent/CollapsingTopBarExitState.kt
@@ -22,6 +22,8 @@ import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -121,14 +123,16 @@ class CollapsingTopBarExitState internal constructor(
     /**
      * Whether top bar exit height is fully exited/collapsed. Disabled state is never exited.
      */
-    val isFullyExited: Boolean
-        get() = isEnabled && exitHeight == collapsedHeight
+    val isFullyExited: Boolean by derivedStateOf {
+        isEnabled && exitHeight == collapsedHeight
+    }
 
     /**
      * Whether top bar exit height is fully entered/expanded. Disabled state is always entered.
      */
-    val isFullyEntered: Boolean
-        get() = exitHeight == 0f
+    val isFullyEntered: Boolean by derivedStateOf {
+        exitHeight == 0f
+    }
 
     private val collapsedHeight: Float
         get() = collapsedHeightState.floatValue

--- a/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/scaffold/CollapsingTopBarScaffoldScrollMode.kt
+++ b/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/scaffold/CollapsingTopBarScaffoldScrollMode.kt
@@ -98,7 +98,7 @@ data class CollapsingTopBarScaffoldScrollMode internal constructor(
     ): CollapsingTopBarSnapScope {
         return when {
             wasMovingUp -> scaffoldState
-            scaffoldState.topBarState.layoutInfo.isCollapsed -> scaffoldState.exitState
+            scaffoldState.topBarState.isCollapsed -> scaffoldState.exitState
             else -> scaffoldState.topBarState
         }
     }

--- a/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/scaffold/CollapsingTopBarScaffoldState.kt
+++ b/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/scaffold/CollapsingTopBarScaffoldState.kt
@@ -20,6 +20,8 @@ import androidx.compose.animation.core.AnimationSpec
 import androidx.compose.foundation.gestures.ScrollScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -74,15 +76,17 @@ class CollapsingTopBarScaffoldState internal constructor(
     /**
      * Whether top bar is fully expanded and entered.
      */
-    val isExpanded: Boolean
-        get() = topBarState.isExpanded && exitState.isFullyEntered
+    val isExpanded: Boolean by derivedStateOf {
+        topBarState.isExpanded && exitState.isFullyEntered
+    }
 
     /**
      * Whether top bar is fully collapsed and exited (if exit is enabled).
      */
-    val isCollapsed: Boolean
-        get() = topBarState.isCollapsed &&
+    val isCollapsed: Boolean by derivedStateOf {
+        topBarState.isCollapsed &&
             (!exitState.isEnabled || exitState.isFullyExited)
+    }
 
     override suspend fun expand(animationSpec: AnimationSpec<Float>) {
         animateScrollTo(animationSpec) {

--- a/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/scaffold/CollapsingTopBarScaffoldState.kt
+++ b/ComposeCollapsingTopBar/src/main/java/com/flaringapp/compose/topbar/scaffold/CollapsingTopBarScaffoldState.kt
@@ -75,13 +75,13 @@ class CollapsingTopBarScaffoldState internal constructor(
      * Whether top bar is fully expanded and entered.
      */
     val isExpanded: Boolean
-        get() = topBarState.layoutInfo.isExpanded && exitState.isFullyEntered
+        get() = topBarState.isExpanded && exitState.isFullyEntered
 
     /**
      * Whether top bar is fully collapsed and exited (if exit is enabled).
      */
     val isCollapsed: Boolean
-        get() = topBarState.layoutInfo.isCollapsed &&
+        get() = topBarState.isCollapsed &&
             (!exitState.isEnabled || exitState.isFullyExited)
 
     override suspend fun expand(animationSpec: AnimationSpec<Float>) {

--- a/app/src/main/java/com/flaringapp/compose/topbar/ui/samples/CollapsingTopBarSampleGroups.kt
+++ b/app/src/main/java/com/flaringapp/compose/topbar/ui/samples/CollapsingTopBarSampleGroups.kt
@@ -17,6 +17,7 @@
 package com.flaringapp.compose.topbar.ui.samples
 
 import com.flaringapp.compose.topbar.ui.samples.advanced.AppBarScrimSample
+import com.flaringapp.compose.topbar.ui.samples.advanced.AppBarShadowSample
 import com.flaringapp.compose.topbar.ui.samples.advanced.FloatingElementSample
 import com.flaringapp.compose.topbar.ui.samples.advanced.ManualCollapsingControlsSample
 import com.flaringapp.compose.topbar.ui.samples.advanced.ParallaxCollapsingSample
@@ -57,6 +58,7 @@ object CollapsingTopBarSampleGroups {
         get() = listOf(
             ParallaxCollapsingSample,
             SnapCollapsingSample,
+            AppBarShadowSample,
             AppBarScrimSample,
             ManualCollapsingControlsSample,
             FloatingElementSample,

--- a/app/src/main/java/com/flaringapp/compose/topbar/ui/samples/advanced/AppBarShadowSample.kt
+++ b/app/src/main/java/com/flaringapp/compose/topbar/ui/samples/advanced/AppBarShadowSample.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2024 Flaringapp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.flaringapp.compose.topbar.ui.samples.advanced
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.flaringapp.compose.topbar.scaffold.CollapsingTopBarScaffold
+import com.flaringapp.compose.topbar.scaffold.CollapsingTopBarScaffoldScrollMode
+import com.flaringapp.compose.topbar.scaffold.rememberCollapsingTopBarScaffoldState
+import com.flaringapp.compose.topbar.ui.samples.CollapsingTopBarSample
+import com.flaringapp.compose.topbar.ui.samples.CollapsingTopBarSampleDogDefaults
+import com.flaringapp.compose.topbar.ui.samples.common.SampleContent
+import com.flaringapp.compose.topbar.ui.samples.common.SampleTopAppBar
+import com.flaringapp.compose.topbar.ui.samples.common.SampleTopBarImage
+import com.flaringapp.compose.topbar.ui.theme.ComposeCollapsingTopBarTheme
+
+object AppBarShadowSample : CollapsingTopBarSample {
+
+    override val name: String = "App Bar Shadow"
+
+    @Composable
+    override fun Content(onBack: () -> Unit) {
+        AppBarShadowSampleContent(onBack = onBack)
+    }
+}
+
+@Composable
+fun AppBarShadowSampleContent(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        CollapsingContent(
+            onBack = onBack,
+        )
+    }
+}
+
+@Composable
+private fun CollapsingContent(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state = rememberCollapsingTopBarScaffoldState()
+
+    val topBarShadowElevation by animateDpAsState(
+        label = "ShadowAnimation",
+        targetValue = if (state.topBarState.isCollapsed) 12.dp else 0.dp,
+    )
+
+    CollapsingTopBarScaffold(
+        modifier = modifier,
+        state = state,
+        scrollMode = CollapsingTopBarScaffoldScrollMode.collapse(expandAlways = false),
+        topBarModifier = Modifier.graphicsLayer {
+            shadowElevation = topBarShadowElevation.toPx()
+        },
+        topBar = {
+            SampleTopBarImage(
+                dog = CollapsingTopBarSampleDogDefaults.Advanced,
+            )
+
+            SampleTopAppBar(
+                title = "App Bar Shadow",
+                onBack = onBack,
+            )
+        },
+        body = {
+            SampleContent()
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    ComposeCollapsingTopBarTheme {
+        AppBarShadowSampleContent(
+            onBack = {},
+        )
+    }
+}

--- a/app/src/main/java/com/flaringapp/compose/topbar/ui/samples/scaffold/ScaffoldStateControls.kt
+++ b/app/src/main/java/com/flaringapp/compose/topbar/ui/samples/scaffold/ScaffoldStateControls.kt
@@ -61,8 +61,8 @@ fun ScaffoldStateControls(
             modifier = Modifier.weight(1f),
             state = state.topBarState,
             name = "Top Bar",
-            isExpanded = { it.layoutInfo.isExpanded },
-            isCollapsed = { it.layoutInfo.isCollapsed },
+            isExpanded = { it.isExpanded },
+            isCollapsed = { it.isCollapsed },
         )
 
         if (state.exitState.isEnabled) {


### PR DESCRIPTION
# Optimisations

## Top Bar

`CollapsingTopBarState` now has `isCollapsed` and `isExpanded` properties backed by derived state to prevent unnecessary recompositions. Corresponding `CollapsingTopBarLayoutInfo` fields are now internal.

## Exit

Change `isFullyExited` and `isFullyEntered` properties to be backed by derived state to prevent unnecessary recompositions.

## Scaffold

Change `isExpanded` and `isCollapsed` properties to be backed by derived state to prevent unnecessary recompositions.

# Improvements

`CollapsingTopBar` now has default value of `state` parameter.

`CollapsingTopBarScaffold` now implements 'upwards' motion of `topBar`: it makes possible to apply visual `topBarModifier` that slides up as top bar collapses.

# Samples

Add top app bar shadow sample.
